### PR TITLE
README.md updated to work on a Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Great for usability testing recordings and screencasts, stopwatch is included.
 See it working in action: [Click here](https://hamsterbacke23.github.io/webcamdisplay/)
 
 ## Local development
-Start the webpack server 
+Start the webpack server and then start the system
 ```bash
+npm install
 npm start
 ```


### PR DESCRIPTION
At least on a Mac, you need to run npm install first than then npm start otherwise webpack-dev-server does not run